### PR TITLE
recipes-kernel: linux: fix white characters

### DIFF
--- a/recipes-kernel/linux/grinn-astra-1680-ada/grinn-astra-1680-ada.dts
+++ b/recipes-kernel/linux/grinn-astra-1680-ada/grinn-astra-1680-ada.dts
@@ -39,20 +39,20 @@
 			enable-active-high;
 			gpio = <&portb 12 GPIO_ACTIVE_HIGH>;
 		};
-    };
+	};
 };
 
 &pinctrl {
-    sdhci1_pmux: sdhci1-pmux {
-        groups = "SDIO_CDn";
-        function = "sdio";
-        drive-strength = <7>;
-    };
+	sdhci1_pmux: sdhci1-pmux {
+		groups = "SDIO_CDn";
+		function = "sdio";
+		drive-strength = <7>;
+	};
 
-    sdhci1_gpio_pmux: sdhci1-gpio-pmux {
-        groups = "SDIO_WP";
-        function = "gpio";
-    };
+	sdhci1_gpio_pmux: sdhci1-gpio-pmux {
+		groups = "SDIO_WP";
+		function = "gpio";
+	};
 };
 
 &mdio0 {
@@ -86,4 +86,3 @@
 	pad-sn = /bits/ 8 <4>;
 	vmmc-supply = <&vmmc_sdhci1>;
 };
-

--- a/recipes-kernel/linux/grinn-astra-1680-evb/grinn-astra-1680-evb.dts
+++ b/recipes-kernel/linux/grinn-astra-1680-evb/grinn-astra-1680-evb.dts
@@ -34,29 +34,29 @@
 		compatible = "gpio-leds";
 		status = "okay";
 
-        ir_led_en1: led0 {
+		ir_led_en1: led0 {
 			gpios = <&portb 5 GPIO_ACTIVE_HIGH>;
 			default-state = "off";
 			pinctrl-0 = <&ir_led_en1_pmux>;
 		};
 
-        ir_led_en2: led1 {
+		ir_led_en2: led1 {
 			gpios = <&portb 4 GPIO_ACTIVE_HIGH>;
 			default-state = "off";
 			pinctrl-0 = <&ir_led_en2_pmux>;
 		};
 	};
 
-    regulators {
-        usb3_vbus: usb3_vbus {
-            compatible = "regulator-fixed";
-            regulator-min-microvolt = <5000000>;
-            regulator-max-microvolt = <5000000>;
-            regulator-name = "usb3-vbus";
-            enable-active-high;
-            gpio = <&portb 12 GPIO_ACTIVE_HIGH>;
-        };
-    };
+	regulators {
+		usb3_vbus: usb3_vbus {
+			compatible = "regulator-fixed";
+			regulator-min-microvolt = <5000000>;
+			regulator-max-microvolt = <5000000>;
+			regulator-name = "usb3-vbus";
+			enable-active-high;
+			gpio = <&portb 12 GPIO_ACTIVE_HIGH>;
+		};
+	};
 };
 
 &pinctrl {
@@ -96,9 +96,8 @@
 };
 
 &xhci0 {
-    status = "okay";
-    vbus-supply = <&usb3_vbus>;
-    pinctrl-0 = <&usb3_vbus_pmux>;
-    pinctrl-names = "default";
+	status = "okay";
+	vbus-supply = <&usb3_vbus>;
+	pinctrl-0 = <&usb3_vbus_pmux>;
+	pinctrl-names = "default";
 };
-

--- a/recipes-kernel/linux/grinn-astra-1680/grinn-astra-1680.dtsi
+++ b/recipes-kernel/linux/grinn-astra-1680/grinn-astra-1680.dtsi
@@ -210,7 +210,6 @@
 		function = "uart3";
 		drive-strength = <3>;
 	};
-
 };
 
 &sm_pinctrl {
@@ -270,7 +269,7 @@
 	pwm2_pmux: pwm2-pmux {
 		groups = "I2S1_DO2";
 		function = "pwm";
-        };
+	};
 
 	i2s1_pmux: i2s1-pmux {
 		groups = "I2S1_BCLKIO", "I2S1_LRCKIO", "I2S1_DO0", "I2S1_MCLK";
@@ -399,7 +398,7 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&i2c1_pmux>;
 
-    vcpu: regulator@60 {
+	vcpu: regulator@60 {
 		compatible = "silergy,sy20257n";
 		reg = <0x60>;
 		status = "okay";
@@ -417,7 +416,7 @@
 	pinctrl-names = "default";
 	pinctrl-0 = <&i2c2_pmux>;
 
-    vcore: regulator@60 {
+	vcore: regulator@60 {
 		compatible = "silergy,sy20257n";
 		reg = <0x60>;
 		status = "okay";
@@ -495,7 +494,7 @@
 };
 
 &vpp {
-        status = "okay";
+	status = "okay";
 };
 
 &isp_vsi {
@@ -551,7 +550,7 @@
 	 * 			1 - MIPI Only
 	 *			2 - Dual Mode PIP
 	 *
- 	 * Supported types:	0 - HDMI
+	 * Supported types:	0 - HDMI
 	 * 		  	3 - MIPI-DSI
 	 */
 	disp-mode = <2>;
@@ -619,14 +618,14 @@
 		Null_Pkt = <0>;
 		Byte_clk = <84090>;
 
-	/*  COMMAND= Command for initialisation
-	*  Format - <CMD> <Payloadlength-n> <BYTE1> <...> <BYTEn>
-	*  Long write Ex: 39 04 FF 98 81 03
+		/*  COMMAND= Command for initialisation
+		*  Format - <CMD> <Payloadlength-n> <BYTE1> <...> <BYTEn>
+		*  Long write Ex: 39 04 FF 98 81 03
 
-	*  Delay in micro seconds Command format: 0xFF <4BYTE delay>
-	*  Delay for 100ms(100000us => 0x000186A0)
-	*  	- FF A0 86 01 00
-	*/
+		*  Delay in micro seconds Command format: 0xFF <4BYTE delay>
+		*  Delay for 100ms(100000us => 0x000186A0)
+		*  	- FF A0 86 01 00
+		*/
 		command = /bits/ 8 <0x29  0x06 0x10  0x02  0x03  0x00  0x00 0x00
 				0x29  0x06 0x64  0x01  0x0C  0x00  0x00 0x00
 				0x29  0x06 0x68  0x01  0x0C  0x00  0x00 0x00

--- a/recipes-kernel/linux/linux-syna_%.bbappend
+++ b/recipes-kernel/linux/linux-syna_%.bbappend
@@ -12,16 +12,16 @@ SRC_URI:append = " \
 	file://${DTS_ADA}.dts \
 	file://${DTS_EVB}.dts \
 	file://${DTSI}.dtsi \
-    file://regulator.cfg \
-    file://0001-Add-sy20257-regulator.patch \
+	file://regulator.cfg \
+	file://0001-Add-sy20257-regulator.patch \
 "
 
 SRC_URI:append:grinn-astra-1680-ada = " \
 "
 
 SRC_URI:append:grinn-astra-1680-evb = " \
-    file://enable-led-gpio.cfg \
-    file://eth.cfg \
+	file://enable-led-gpio.cfg \
+	file://eth.cfg \
 "
 
 do_compile:prepend() {
@@ -29,4 +29,3 @@ do_compile:prepend() {
 	cp ${WORKDIR}/${DTS_ADA}.dts ${DT_DIR}/
 	cp ${WORKDIR}/${DTS_EVB}.dts ${DT_DIR}/
 }
-


### PR DESCRIPTION
Make recipe files consistent in terms of white characters.