### PR TITLE
templates: bblayers: add meta-networking openembedded layer

### DIFF
--- a/conf/templates/default/bblayers.conf.sample
+++ b/conf/templates/default/bblayers.conf.sample
@@ -12,6 +12,7 @@ BBLAYERS ?= " \
   ##OEROOT##/../meta-openembedded/meta-oe \
   ##OEROOT##/../meta-openembedded/meta-python \
   ##OEROOT##/../meta-openembedded/meta-multimedia \
+  ##OEROOT##/../meta-openembedded/meta-networking \
   ##OEROOT##/../meta-qt5 \
   ##OEROOT##/../meta-synaptics \
   ##OEROOT##/../meta-swupdate \


### PR DESCRIPTION
meta-synaptics v1.6.0 layer requires networkmanager package provided by meta-networking layer from openembedded. Therefore include this layer in bblayers template.