### PR TITLE
recipes-bsp: syna-u-boot: fix model string

### DIFF
--- a/recipes-bsp/syna-bootloader/grinn-astra-1680-ada/grinn-astra-1680-ada.dts
+++ b/recipes-bsp/syna-bootloader/grinn-astra-1680-ada/grinn-astra-1680-ada.dts
@@ -28,7 +28,7 @@
 #include "include/dt-bindings/gpio/gpio.h"
 
 / {
-	model = "Grinn Astra 1690 ada";
+	model = "Grinn Astra 1680 ada";
 	compatible = "Synaptics,dolphin", "Synaptics,asserial";
 
 	memory {

--- a/recipes-bsp/syna-bootloader/grinn-astra-1680-evb/grinn-astra-1680-evb.dts
+++ b/recipes-bsp/syna-bootloader/grinn-astra-1680-evb/grinn-astra-1680-evb.dts
@@ -28,7 +28,7 @@
 #include "include/dt-bindings/gpio/gpio.h"
 
 / {
-	model = "Grinn Astra 1080 evb";
+	model = "Grinn Astra 1680 evb";
 	compatible = "Synaptics,dolphin", "Synaptics,asserial";
 
 	memory {


### PR DESCRIPTION
Fix typos in naming of Grinn Astra machines.